### PR TITLE
Use pwd to work correctly with symlinks

### DIFF
--- a/src/N98/Util/OperatingSystem.php
+++ b/src/N98/Util/OperatingSystem.php
@@ -113,6 +113,9 @@ class OperatingSystem
      */
     public static function getCwd()
     {
+        if (self::isLinux() || self::isMacOs()) {
+            return exec('pwd');
+        }
         return getcwd();
     }
 


### PR DESCRIPTION
Our magento shops use symlinks for some subdirectories to make them compatible with our deployment process. For example the media folder which contains user generated content and does not need to be overwritten after our deploy.

When we run magerun commands (for example db:dump) from this directory an exception is thrown:
```    
[InvalidArgumentException]
"app/etc/local.xml"-file '/app/etc/local.xml' is not readable
```

This is because Magerun does Magento detection starting at the current working directory, which is determined by `getcwd()`. However this method always resolves the symlink target which obviously causes issues in our case. This change will not resolve the symlink but return the path of the symlink. I cannot think of any use case where this will cause issues for other users.